### PR TITLE
Improvements to the first startup (fool proofing)

### DIFF
--- a/Wabbajack/AppState.cs
+++ b/Wabbajack/AppState.cs
@@ -45,12 +45,27 @@ namespace Wabbajack
 
         public AppState(Dispatcher d, string mode)
         {
+            // Ensure WJ is not being run in a download directory.
             if (Assembly.GetEntryAssembly().Location.ToLower().Contains("\\downloads\\"))
             {
                 MessageBox.Show(
                     "This app seems to be running inside a folder called `Downloads`, such folders are often highly monitored by Antivirus software and they can often " +
                     "conflict with the operations Wabbajack needs to perform. Please move this executable outside of your `Downloads` folder and then restart the app.",
                     "Cannot run inside `Downloads`",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error);
+                Environment.Exit(1);
+            }
+
+            // Check if LOOT is installed.
+            string appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            string lootAppDataPath = $"{appDataPath}\\LOOT";
+            if (!Directory.Exists(lootAppDataPath))
+            {
+                MessageBox.Show(
+                   $"Wabbajack could not locate the LOOT application data at {lootAppDataPath}. " +
+                    "Please make sure that LOOT is installed correctly before running Wabbajack.",
+                    "LOOT not found",
                     MessageBoxButton.OK,
                     MessageBoxImage.Error);
                 Environment.Exit(1);

--- a/Wabbajack/MainWindow.xaml
+++ b/Wabbajack/MainWindow.xaml
@@ -36,7 +36,7 @@
                 <RowDefinition MinHeight="10" />
                 <RowDefinition />
             </Grid.RowDefinitions>
-            <Label Grid.Row="0" Content="MO2 Location:" Grid.Column="0" />
+            <Label Grid.Row="0" Content="MO2 Profile Location:" Grid.Column="0" />
             <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Location}" IsEnabled="{Binding UIReady}"/>
             <Button Grid.Row="0" Content="Select" MinWidth="80" Grid.Column="2" Command="{Binding ChangePath}" IsEnabled="{Binding UIReady}"/>
             <Label Grid.Row="2" Content="Download Location:" Grid.Column="0" />


### PR DESCRIPTION
**+** Added startup check to determine if LOOT is installed. Without this check, WJ encounters an exception at the very end of the build process.
~ Changed the label for the MO2 profile location selection to "MO2 Profile Location" to clarify what needs to be selected.

Signed-off-by: Christopher Cyclonit Klinge <christ.klinge@web.de>