### PR TITLE
Add validation to prevent Wabbajack from crashing when selecting invalid profile directory or starting compilation without specifying profile directory

### DIFF
--- a/Wabbajack/AppState.cs
+++ b/Wabbajack/AppState.cs
@@ -305,13 +305,15 @@ namespace Wabbajack
                 if (folder != null)
                 {
                     var file = Path.Combine(folder, "modlist.txt");
-                    if (!File.Exists(file))
+                    if(File.Exists(file))
+                    {
+                        Location = file;
+                        ConfigureForBuild();
+                    }
+                    else
                     {
                         Utils.Log($"No modlist.txt found at {file}");
                     }
-
-                    Location = file;
-                    ConfigureForBuild();
                 }
             }
         }

--- a/Wabbajack/AppState.cs
+++ b/Wabbajack/AppState.cs
@@ -381,32 +381,40 @@ namespace Wabbajack
             }
             else
             {
-                var compiler = new Compiler(_mo2Folder, msg => LogMsg(msg));
-                compiler.IgnoreMissingFiles = IgnoreMissingFiles;
-                compiler.MO2Profile = ModListName;
-                var th = new Thread(() =>
+                if (_mo2Folder != null)
                 {
-                    UIReady = false;
-                    try
+                    var compiler = new Compiler(_mo2Folder, msg => LogMsg(msg));
+                    compiler.IgnoreMissingFiles = IgnoreMissingFiles;
+                    compiler.MO2Profile = ModListName;
+                    var th = new Thread(() =>
                     {
-                        compiler.Compile();
-                        if (compiler.ModList != null && compiler.ModList.ReportHTML != null)
-                            HTMLReport = compiler.ModList.ReportHTML;
-                    }
-                    catch (Exception ex)
-                    {
-                        while (ex.InnerException != null) ex = ex.InnerException;
-                        LogMsg(ex.StackTrace);
-                        LogMsg(ex.ToString());
-                        LogMsg($"{ex.Message} - Can't continue");
-                    }
-                    finally
-                    {
-                        UIReady = true;
-                    }
-                });
-                th.Priority = ThreadPriority.BelowNormal;
-                th.Start();
+                        UIReady = false;
+                        try
+                        {
+                            compiler.Compile();
+                            if (compiler.ModList != null && compiler.ModList.ReportHTML != null)
+                                HTMLReport = compiler.ModList.ReportHTML;
+                        }
+                        catch (Exception ex)
+                        {
+                            while (ex.InnerException != null) ex = ex.InnerException;
+                            LogMsg(ex.StackTrace);
+                            LogMsg(ex.ToString());
+                            LogMsg($"{ex.Message} - Can't continue");
+                        }
+                        finally
+                        {
+                            UIReady = true;
+                        }
+                    });
+                    th.Priority = ThreadPriority.BelowNormal;
+                    th.Start();
+                }
+                else
+                {
+                    Utils.Log("Cannot compile modlist: no valid Mod Organizer profile directory selected.");
+                    UIReady = true;
+                }
             }
         }
 


### PR DESCRIPTION
I think it's more user-friendly to notify the user in the log about what they are doing wrong instead of crashing and letting the user find the issue through the log.