### PR TITLE
Improved location validation

### DIFF
--- a/Wabbajack/AppState.cs
+++ b/Wabbajack/AppState.cs
@@ -16,7 +16,7 @@ using Wabbajack.Properties;
 
 namespace Wabbajack
 {
-    internal class AppState : INotifyPropertyChanged
+    internal class AppState : INotifyPropertyChanged, IDataErrorInfo
     {
         private ICommand _begin;
 
@@ -157,6 +157,7 @@ namespace Wabbajack
                 OnPropertyChanged("Location");
             }
         }
+        
 
         public string DownloadLocation
         {
@@ -315,7 +316,47 @@ namespace Wabbajack
 
         public void OnPropertyChanged(string name)
         {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+            //PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+            if(PropertyChanged != null)
+            {
+                PropertyChanged(this, new PropertyChangedEventArgs(name));
+            }
+        }
+        public string Error
+        {
+            get { return "Error"; }
+        }
+
+        public string this[string columnName]
+        {
+            get
+            {
+                return Validate(columnName);
+            }
+        }
+        private string Validate(string columnName)
+        {
+            string validationMessage = null;
+            switch (columnName)
+            {
+                case "Location":
+                    if (Location == null)
+                    {
+                        validationMessage = null;
+                    }
+                    else if (Location != null && Directory.Exists(Location) && File.Exists(Path.Combine(Location, "modlist.txt")))
+                    {
+                        Location = Path.Combine(Location, "modlist.txt");
+                        validationMessage = null;
+                        ConfigureForBuild();
+                    }
+                    else
+                    {
+                        validationMessage = "Invalid Mod Organizer profile directory";
+                    }
+                    break;
+            }
+            return validationMessage;
         }
 
         private void UpdateLoop()
@@ -421,20 +462,7 @@ namespace Wabbajack
             else
             {
                 var folder = UIUtils.ShowFolderSelectionDialog("Select Your MO2 profile directory");
-
-                if (folder != null)
-                {
-                    var file = Path.Combine(folder, "modlist.txt");
-                    if(File.Exists(file))
-                    {
-                        Location = file;
-                        ConfigureForBuild();
-                    }
-                    else
-                    {
-                        Utils.Log($"No modlist.txt found at {file}");
-                    }
-                }
+                Location = folder;
             }
         }
 
@@ -500,42 +528,40 @@ namespace Wabbajack
                 th.Priority = ThreadPriority.BelowNormal;
                 th.Start();
             }
+            else if (_mo2Folder != null)
+            {
+                var compiler = new Compiler(_mo2Folder, msg => LogMsg(msg));
+                compiler.IgnoreMissingFiles = IgnoreMissingFiles;
+                compiler.MO2Profile = ModListName;
+                var th = new Thread(() =>
+                {
+                    UIReady = false;
+                    try
+                    {
+                        compiler.Compile();
+                        if (compiler.ModList != null && compiler.ModList.ReportHTML != null)
+                            HTMLReport = compiler.ModList.ReportHTML;
+                    }
+                    catch (Exception ex)
+                    {
+                        while (ex.InnerException != null) ex = ex.InnerException;
+                        LogMsg(ex.StackTrace);
+                        LogMsg(ex.ToString());
+                        LogMsg($"{ex.Message} - Can't continue");
+                    }
+                    finally
+                    {
+                        UIReady = true;
+                    }
+                });
+                th.Priority = ThreadPriority.BelowNormal;
+                th.Start();
+            }
             else
             {
-                if (_mo2Folder != null)
-                {
-                    var compiler = new Compiler(_mo2Folder, msg => LogMsg(msg));
-                    compiler.IgnoreMissingFiles = IgnoreMissingFiles;
-                    compiler.MO2Profile = ModListName;
-                    var th = new Thread(() =>
-                    {
-                        UIReady = false;
-                        try
-                        {
-                            compiler.Compile();
-                            if (compiler.ModList != null && compiler.ModList.ReportHTML != null)
-                                HTMLReport = compiler.ModList.ReportHTML;
-                        }
-                        catch (Exception ex)
-                        {
-                            while (ex.InnerException != null) ex = ex.InnerException;
-                            LogMsg(ex.StackTrace);
-                            LogMsg(ex.ToString());
-                            LogMsg($"{ex.Message} - Can't continue");
-                        }
-                        finally
-                        {
-                            UIReady = true;
-                        }
-                    });
-                    th.Priority = ThreadPriority.BelowNormal;
-                    th.Start();
-                }
-                else
-                {
-                    Utils.Log("Cannot compile modlist: no valid Mod Organizer profile directory selected.");
-                    UIReady = true;
-                }
+                Utils.Log("Cannot compile modlist: no valid Mod Organizer profile directory selected.");
+                UIReady = true;
+            }
             }
         }
 
@@ -547,5 +573,4 @@ namespace Wabbajack
             public string Msg { get; internal set; }
             public int ID { get; internal set; }
         }
-    }
 }

--- a/Wabbajack/AppState.cs
+++ b/Wabbajack/AppState.cs
@@ -316,7 +316,6 @@ namespace Wabbajack
 
         public void OnPropertyChanged(string name)
         {
-            //PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
             if(PropertyChanged != null)
             {
                 PropertyChanged(this, new PropertyChangedEventArgs(name));

--- a/Wabbajack/MainWindow.xaml
+++ b/Wabbajack/MainWindow.xaml
@@ -64,8 +64,8 @@
                 <RowDefinition MinHeight="10" />
                 <RowDefinition />
             </Grid.RowDefinitions>
-            <Label Grid.Row="0" Content="MO2 Location:" Grid.Column="0" />
-            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Location, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}" IsEnabled="{Binding UIReady}"/>
+            <Label Grid.Row="0" Content="MO2 Profile:" Grid.Column="0" />
+            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Location, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True, NotifyOnValidationError=True}" IsEnabled="{Binding UIReady}"/>
             <Button Grid.Row="0" Content="Select" MinWidth="80" Grid.Column="2" Command="{Binding ChangePath}" IsEnabled="{Binding UIReady}"/>
             <Label Grid.Row="2" Content="Download Location:" Grid.Column="0" />
             <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding DownloadLocation}" IsEnabled="{Binding UIReady}"/>

--- a/Wabbajack/MainWindow.xaml
+++ b/Wabbajack/MainWindow.xaml
@@ -65,7 +65,7 @@
                 <RowDefinition />
             </Grid.RowDefinitions>
             <Label Grid.Row="0" Content="MO2 Location:" Grid.Column="0" />
-            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Location}" IsEnabled="{Binding UIReady}"/>
+            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Location, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}" IsEnabled="{Binding UIReady}"/>
             <Button Grid.Row="0" Content="Select" MinWidth="80" Grid.Column="2" Command="{Binding ChangePath}" IsEnabled="{Binding UIReady}"/>
             <Label Grid.Row="2" Content="Download Location:" Grid.Column="0" />
             <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding DownloadLocation}" IsEnabled="{Binding UIReady}"/>

--- a/Wabbajack/Themes/Styles.xaml
+++ b/Wabbajack/Themes/Styles.xaml
@@ -838,6 +838,9 @@
             </Setter.Value>
         </Setter>
         <Style.Triggers>
+            <DataTrigger Binding="{Binding Path=(Validation.HasError), RelativeSource={RelativeSource self}}" Value="True">
+                <Setter Property="ToolTip" Value="{Binding RelativeSource={x:Static RelativeSource.Self}, Path=(Validation.Errors)[0].ErrorContent}"/>
+            </DataTrigger>
             <!--<MultiTrigger>
                 <MultiTrigger.Conditions>
                     <Condition Property="IsInactiveSelectionHighlightEnabled" Value="true"/>


### PR DESCRIPTION
- Location TextBox will now be highlighted in red when an invalid mod profile directory has been selected.
- Location TextBox will get additional tooltip to notify the user about what's wrong with their currently selected location.
- Changed the label that says "MO2 Directory" to "MO2 Profile" to prevent confusion with actual MO2 installation folder.
- Other fields can now also be easily validated by adding them to the switch in the Validate() method (AppState.cs).